### PR TITLE
Use defaultRecorderBuckets for Histogram

### DIFF
--- a/Sources/Prometheus/PrometheusMetrics.swift
+++ b/Sources/Prometheus/PrometheusMetrics.swift
@@ -204,7 +204,7 @@ public struct PrometheusMetricsFactory: PrometheusWrappedMetricsFactory {
 
     private func makeHistogram(label: String, dimensions: [(String, String)]) -> RecorderHandler {
         let label = configuration.labelSanitizer.sanitize(label)
-        let histogram = client.createHistogram(forType: Double.self, named: label)
+        let histogram = client.createHistogram(forType: Double.self, named: label, buckets: configuration.defaultRecorderBuckets)
         return MetricsHistogram(histogram: histogram, dimensions: dimensions.sanitized())
     }
 


### PR DESCRIPTION


<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->

### Checklist
- [x] The provided tests still run.
- [ ] I've created new tests where needed.
- [ ] I've updated the documentation if necessary.

I've not updated tests (mostly because I entirely made this change on GitHub) but we totally should to prevent regression. Created this branch so I can do a quick validation by pointing my project to this branch.

### Motivation and Context

Fixes #74

### Description

Pass the user-provided default for the buckets to the create histogram function. This value defaults to the same value which the function defaults to - so unless the user has overridden the default buckets value, this change will not impact existing code.