### PR TITLE
Remove .jazzy.yaml

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,7 +1,0 @@
-author: 'MrLotU'
-author_url: 'https://github.com/MrLotU'
-github_url: 'https://github.com/swift-server-community/SwiftPrometheus'
-github_file_prefix: 'https://github.com/swift-server-community/SwiftPrometheus/tree/master/'
-theme: 'fullwidth'
-undocumented_text: ''
-root_url: 'https://swift-server-community.github.io/SwiftPrometheus/'


### PR DESCRIPTION
Remove `.jazzy.yaml`. We use docc now.