### PR TITLE
Rename destroyMetric to unregisterMetric

### DIFF
--- a/Sources/Prometheus/PrometheusCollectorRegistry.swift
+++ b/Sources/Prometheus/PrometheusCollectorRegistry.swift
@@ -386,8 +386,13 @@ public final class PrometheusCollectorRegistry: Sendable {
     }
 
     // MARK: Destroying Metrics
-
-    public func destroyCounter(_ counter: Counter) {
+    
+    /// Unregisters a ``Counter`` from the ``PrometheusCollectorRegistry``. This means that the provided ``Counter``
+    /// will not be included in future ``emit(into:)`` calls.
+    ///
+    /// - Note: If the provided ``Counter`` is unknown to the registry this function call will be ignored
+    /// - Parameter counter: The ``Counter`` that shall be removed from the registry
+    public func unregisterCounter(_ counter: Counter) {
         self.box.withLockedValue { store in
             switch store[counter.name] {
             case .counter(let storedCounter):
@@ -404,7 +409,12 @@ public final class PrometheusCollectorRegistry: Sendable {
         }
     }
 
-    public func destroyGauge(_ gauge: Gauge) {
+    /// Unregisters a ``Gauge`` from the ``PrometheusCollectorRegistry``. This means that the provided ``Gauge``
+    /// will not be included in future ``emit(into:)`` calls.
+    ///
+    /// - Note: If the provided ``Gauge`` is unknown to the registry this function call will be ignored
+    /// - Parameter gauge: The ``Gauge`` that shall be removed from the registry
+    public func unregisterGauge(_ gauge: Gauge) {
         self.box.withLockedValue { store in
             switch store[gauge.name] {
             case .gauge(let storedGauge):
@@ -421,7 +431,12 @@ public final class PrometheusCollectorRegistry: Sendable {
         }
     }
 
-    public func destroyTimeHistogram(_ histogram: DurationHistogram) {
+    /// Unregisters a ``DurationHistogram`` from the ``PrometheusCollectorRegistry``. This means that this ``DurationHistogram``
+    /// will not be included in future ``emit(into:)`` calls.
+    ///
+    /// - Note: If the provided ``DurationHistogram`` is unknown to the registry this function call will be ignored
+    /// - Parameter histogram: The ``DurationHistogram`` that shall be removed from the registry
+    public func unregisterTimeHistogram(_ histogram: DurationHistogram) {
         self.box.withLockedValue { store in
             switch store[histogram.name] {
             case .durationHistogram(let storedHistogram):
@@ -438,7 +453,12 @@ public final class PrometheusCollectorRegistry: Sendable {
         }
     }
 
-    public func destroyValueHistogram(_ histogram: ValueHistogram) {
+    /// Unregisters a ``ValueHistogram`` from the ``PrometheusCollectorRegistry``. This means that this ``ValueHistogram``
+    /// will not be included in future ``emit(into:)`` calls.
+    ///
+    /// - Note: If the provided ``ValueHistogram`` is unknown to the registry this function call will be ignored
+    /// - Parameter histogram: The ``ValueHistogram`` that shall be removed from the registry
+    public func unregisterValueHistogram(_ histogram: ValueHistogram) {
         self.box.withLockedValue { store in
             switch store[histogram.name] {
             case .valueHistogram(let storedHistogram):

--- a/Sources/Prometheus/PrometheusMetricsFactory.swift
+++ b/Sources/Prometheus/PrometheusMetricsFactory.swift
@@ -119,22 +119,22 @@ extension PrometheusMetricsFactory: CoreMetrics.MetricsFactory {
         guard let counter = handler as? Counter else {
             return
         }
-        self.registry.destroyCounter(counter)
+        self.registry.unregisterCounter(counter)
     }
 
     public func destroyFloatingPointCounter(_ handler: FloatingPointCounterHandler) {
         guard let counter = handler as? Counter else {
             return
         }
-        self.registry.destroyCounter(counter)
+        self.registry.unregisterCounter(counter)
     }
 
     public func destroyRecorder(_ handler: CoreMetrics.RecorderHandler) {
         switch handler {
         case let gauge as Gauge:
-            self.registry.destroyGauge(gauge)
+            self.registry.unregisterGauge(gauge)
         case let histogram as Histogram<Double>:
-            self.registry.destroyValueHistogram(histogram)
+            self.registry.unregisterValueHistogram(histogram)
         default:
             break
         }
@@ -144,13 +144,13 @@ extension PrometheusMetricsFactory: CoreMetrics.MetricsFactory {
         guard let gauge = handler as? Gauge else {
             return
         }
-        self.registry.destroyGauge(gauge)
+        self.registry.unregisterGauge(gauge)
     }
 
     public func destroyTimer(_ handler: CoreMetrics.TimerHandler) {
         guard let histogram = handler as? Histogram<Duration> else {
             return
         }
-        self.registry.destroyTimeHistogram(histogram)
+        self.registry.unregisterTimeHistogram(histogram)
     }
 }


### PR DESCRIPTION
Renamed the `PrometheusCollectorRegistry` `destroy` methods to `unregister`. this is more in line with the Prometheus [documentation](https://prometheus.io/docs/instrumenting/writing_clientlibs/#overall-structure):

> CollectorRegistry SHOULD offer `register()`/`unregister()` functions, and a Collector SHOULD be allowed to be registered to multiple CollectorRegistrys.

Further this is more in line with what this function actually does. The metrics aren't move only types, that we can actually destroy in the method.

Also added docc comments.