### PR TITLE
Remove generic argument from Histogram

### DIFF
--- a/Sources/Prometheus/Docs.docc/swift-metrics.md
+++ b/Sources/Prometheus/Docs.docc/swift-metrics.md
@@ -111,28 +111,19 @@ generated in a third party library.
 
 #### Default buckets
 
-Swift Metric ``Timer``s are backed by a Prometheus ``DurationHistogram`` and Swift Metric 
-``Recorder``s that aggregate are backed by a Prometheus ``ValueHistogram``. As a user, you can 
+Swift Metric ``Timer``s are backed by a Prometheus ``Histogram`` and Swift Metric 
+``Recorder``s that aggregate are also backed by a Prometheus ``Histogram``. As a user, you can 
 specify which buckets shall be used within the backing ``Histogram``s.
 
 ```swift
 var factory = PrometheusMetricsFactory()
 
-factory.defaultDurationHistogramBuckets = [
-  .milliseconds(5),
-  .milliseconds(10),
-  .milliseconds(25),
-  .milliseconds(50),
-  .milliseconds(100),
+factory.defaultTimerHistogramBuckets = [
+  0.005, 0.01, 0.025, 0.05, 0.1
 ]
 
-factory.defaultValueHistogramBuckets = [
-  5,
-  10,
-  25,
-  50,
-  100,
-  250,
+factory.defaultRecorderHistogramBuckets = [
+  5, 10, 25, 50, 100, 250,
 ]
 MetricSystem.bootstrap(factory)
 
@@ -148,28 +139,19 @@ You can also specify the buckets by metric name:
 ```swift
 var factory = PrometheusMetricsFactory()
 
-factory.defaultDurationHistogramBuckets = [
-  .milliseconds(5),
-  .milliseconds(10),
-  .milliseconds(25),
-  .milliseconds(50),
-  .milliseconds(100),
+factory.defaultTimerHistogramBuckets = [
+  0.005, 0.01, 0.025, 0.05, 0.1
 ]
 
-factory.durationHistogramBuckets["long"] = [
-  .seconds(5),
-  .seconds(10),
-  .seconds(25),
-  .seconds(50),
-  .seconds(100),
+factory.timerHistogramBuckets["long"] = [
+  5, 10, 25, 50, 100
 ] 
 ```
 
 Now a `Timer` with the label "long" will use the buckets  
-`[.seconds(5), .seconds(10), .seconds(25), .seconds(50), .seconds(100),]`, whereas any other 
-`Timer` will use the default buckets 
-`[.milliseconds(5), .milliseconds(10), .milliseconds(25), .milliseconds(50), .milliseconds(100),]`.
+`[5 sec, 10 sec, 25 sec, 50 sec, 100 sec]`, whereas any other 
+`Timer` will use the default buckets `[5 ms, 10ms, 25ms, 50ms, 100ms]`.
 
-The same functionality is also available for ``ValueHistogram`` and aggregating `Recorder`s.
+The same functionality is also available for ``Histogram`` that back aggregating `Recorder`s.
 
 [Swift Metrics]: https://github.com/apple/swift-metrics

--- a/Tests/PrometheusTests/HistogramTests.swift
+++ b/Tests/PrometheusTests/HistogramTests.swift
@@ -18,11 +18,8 @@ import Prometheus
 final class HistogramTests: XCTestCase {
     func testHistogramWithoutDimensions() {
         let client = PrometheusCollectorRegistry()
-        let histogram = client.makeDurationHistogram(name: "foo", labels: [], buckets: [
-            .milliseconds(100),
-            .milliseconds(250),
-            .milliseconds(500),
-            .seconds(1),
+        let histogram = client.makeHistogram(name: "foo", labels: [], buckets: [
+            0.1, 0.25, 0.5, 1,
         ])
 
         var buffer = [UInt8]()
@@ -92,9 +89,9 @@ final class HistogramTests: XCTestCase {
             """
         )
 
-        // Record 80ms
+        // Record 90ms
         buffer.removeAll(keepingCapacity: true)
-        histogram.recordNanoseconds(80_000_000) // 80ms
+        histogram.recordNanoseconds(90_000_000) // 90ms
         client.emit(into: &buffer)
         XCTAssertEqual(String(decoding: buffer, as: Unicode.UTF8.self), """
             # TYPE foo histogram
@@ -103,7 +100,7 @@ final class HistogramTests: XCTestCase {
             foo_bucket{le="0.5"} 2
             foo_bucket{le="1.0"} 3
             foo_bucket{le="+Inf"} 4
-            foo_sum 2.28
+            foo_sum 2.29
             foo_count 4
 
             """
@@ -112,11 +109,8 @@ final class HistogramTests: XCTestCase {
 
     func testHistogramWithOneDimension() {
         let client = PrometheusCollectorRegistry()
-        let histogram = client.makeDurationHistogram(name: "foo", labels: [("bar", "baz")], buckets: [
-            .milliseconds(100),
-            .milliseconds(250),
-            .milliseconds(500),
-            .seconds(1),
+        let histogram = client.makeHistogram(name: "foo", labels: [("bar", "baz")], buckets: [
+            0.1, 0.25, 0.5, 1,
         ])
 
         var buffer = [UInt8]()
@@ -185,9 +179,9 @@ final class HistogramTests: XCTestCase {
             """
         )
 
-        // Record 80ms
+        // Record 90ms
         buffer.removeAll(keepingCapacity: true)
-        histogram.recordNanoseconds(80_000_000) // 80ms
+        histogram.recordNanoseconds(90_000_000) // 90ms
         client.emit(into: &buffer)
         XCTAssertEqual(String(decoding: buffer, as: Unicode.UTF8.self), """
             # TYPE foo histogram
@@ -196,7 +190,7 @@ final class HistogramTests: XCTestCase {
             foo_bucket{bar="baz",le="0.5"} 2
             foo_bucket{bar="baz",le="1.0"} 3
             foo_bucket{bar="baz",le="+Inf"} 4
-            foo_sum{bar="baz"} 2.28
+            foo_sum{bar="baz"} 2.29
             foo_count{bar="baz"} 4
 
             """
@@ -205,11 +199,8 @@ final class HistogramTests: XCTestCase {
 
     func testHistogramWithTwoDimension() {
         let client = PrometheusCollectorRegistry()
-        let histogram = client.makeDurationHistogram(name: "foo", labels: [("bar", "baz"), ("abc", "xyz")], buckets: [
-            .milliseconds(100),
-            .milliseconds(250),
-            .milliseconds(500),
-            .seconds(1),
+        let histogram = client.makeHistogram(name: "foo", labels: [("bar", "baz"), ("abc", "xyz")], buckets: [
+            0.1, 0.25, 0.5, 1,
         ])
 
         var buffer = [UInt8]()
@@ -278,9 +269,9 @@ final class HistogramTests: XCTestCase {
             """
         )
 
-        // Record 80ms
+        // Record 90ms
         buffer.removeAll(keepingCapacity: true)
-        histogram.recordNanoseconds(80_000_000) // 80ms
+        histogram.recordNanoseconds(90_000_000) // 90ms
         client.emit(into: &buffer)
         XCTAssertEqual(String(decoding: buffer, as: Unicode.UTF8.self), """
             # TYPE foo histogram
@@ -289,7 +280,7 @@ final class HistogramTests: XCTestCase {
             foo_bucket{bar="baz",abc="xyz",le="0.5"} 2
             foo_bucket{bar="baz",abc="xyz",le="1.0"} 3
             foo_bucket{bar="baz",abc="xyz",le="+Inf"} 4
-            foo_sum{bar="baz",abc="xyz"} 2.28
+            foo_sum{bar="baz",abc="xyz"} 2.29
             foo_count{bar="baz",abc="xyz"} 4
 
             """

--- a/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
+++ b/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
@@ -113,59 +113,10 @@ final class PrometheusCollectorRegistryTests: XCTestCase {
     }
 
 
-    func testAskingForTheSameTimeHistogramReturnsTheSameTimeHistogram() {
+    func testAskingForTheSameHistogramReturnsTheSameTimeHistogram() {
         let client = PrometheusCollectorRegistry()
-        let histogram1 = client.makeDurationHistogram(name: "foo", buckets: [.seconds(1), .seconds(2), .seconds(3)])
-        let histogram2 = client.makeDurationHistogram(name: "foo", buckets: [.seconds(1), .seconds(2), .seconds(3)])
-
-        XCTAssert(histogram1 === histogram2)
-        histogram1.record(.milliseconds(2500))
-        histogram2.record(.milliseconds(1500))
-
-        var buffer = [UInt8]()
-        client.emit(into: &buffer)
-        XCTAssertEqual(String(decoding: buffer, as: Unicode.UTF8.self), """
-            # TYPE foo histogram
-            foo_bucket{le="1.0"} 0
-            foo_bucket{le="2.0"} 1
-            foo_bucket{le="3.0"} 2
-            foo_bucket{le="+Inf"} 2
-            foo_sum 4.0
-            foo_count 2
-
-            """
-        )
-    }
-
-    func testAskingForTheSameTimeHistogramWithLabelsReturnsTheSameTimeHistogram() {
-        let client = PrometheusCollectorRegistry()
-        let histogram1 = client.makeDurationHistogram(name: "foo", labels: [("bar", "baz")], buckets: [.seconds(1), .seconds(2), .seconds(3)])
-        let histogram2 = client.makeDurationHistogram(name: "foo", labels: [("bar", "baz")], buckets: [.seconds(1), .seconds(2), .seconds(3)])
-
-        XCTAssert(histogram1 === histogram2)
-        histogram1.record(.milliseconds(2500))
-        histogram2.record(.milliseconds(1500))
-
-        var buffer = [UInt8]()
-        client.emit(into: &buffer)
-        XCTAssertEqual(String(decoding: buffer, as: Unicode.UTF8.self), """
-            # TYPE foo histogram
-            foo_bucket{bar="baz",le="1.0"} 0
-            foo_bucket{bar="baz",le="2.0"} 1
-            foo_bucket{bar="baz",le="3.0"} 2
-            foo_bucket{bar="baz",le="+Inf"} 2
-            foo_sum{bar="baz"} 4.0
-            foo_count{bar="baz"} 2
-
-            """
-        )
-    }
-
-
-    func testAskingForTheSameValueHistogramReturnsTheSameTimeHistogram() {
-        let client = PrometheusCollectorRegistry()
-        let histogram1 = client.makeValueHistogram(name: "foo", buckets: [1, 2, 3])
-        let histogram2 = client.makeValueHistogram(name: "foo", buckets: [1, 2, 3])
+        let histogram1 = client.makeHistogram(name: "foo", buckets: [1, 2, 3])
+        let histogram2 = client.makeHistogram(name: "foo", buckets: [1, 2, 3])
 
         XCTAssert(histogram1 === histogram2)
         histogram1.record(2.5)
@@ -186,10 +137,10 @@ final class PrometheusCollectorRegistryTests: XCTestCase {
         )
     }
 
-    func testAskingForTheSameValueHistogramWithLabelsReturnsTheSameTimeHistogram() {
+    func testAskingForTheSameHistogramWithLabelsReturnsTheSameTimeHistogram() {
         let client = PrometheusCollectorRegistry()
-        let histogram1 = client.makeValueHistogram(name: "foo", labels: [("bar", "baz")], buckets: [1, 2, 3])
-        let histogram2 = client.makeValueHistogram(name: "foo", labels: [("bar", "baz")], buckets: [1, 2, 3])
+        let histogram1 = client.makeHistogram(name: "foo", labels: [("bar", "baz")], buckets: [1, 2, 3])
+        let histogram2 = client.makeHistogram(name: "foo", labels: [("bar", "baz")], buckets: [1, 2, 3])
 
         XCTAssert(histogram1 === histogram2)
         histogram1.record(2.5)
@@ -209,5 +160,4 @@ final class PrometheusCollectorRegistryTests: XCTestCase {
             """
         )
     }
-
 }

--- a/Tests/PrometheusTests/PrometheusMetricsFactoryTests.swift
+++ b/Tests/PrometheusTests/PrometheusMetricsFactoryTests.swift
@@ -21,7 +21,7 @@ final class PrometheusMetricsFactoryTests: XCTestCase {
         let factory = PrometheusMetricsFactory(registry: registry)
 
         let timer = factory.makeTimer(label: "foo", dimensions: [("bar", "baz")])
-        XCTAssertNotNil(timer as? Histogram<Duration>)
+        XCTAssertNotNil(timer as? Histogram)
     }
 
     func testMakeRecorders() {
@@ -32,7 +32,7 @@ final class PrometheusMetricsFactoryTests: XCTestCase {
         XCTAssertNotNil(maybeGauge as? Gauge)
 
         let maybeRecorder = factory.makeRecorder(label: "bar", dimensions: [], aggregate: true)
-        XCTAssertNotNil(maybeRecorder as? Histogram<Double>)
+        XCTAssertNotNil(maybeRecorder as? Histogram)
     }
 
     func testMakeCounters() {


### PR DESCRIPTION
In #92, we added a `Histogram` that is generic over the observed type. This means that each `Histogram` was also carrying a generic argument. To make it easier to deal with different `Histogram` types, we added two typealiases `DurationHistogram` and `ValueHistogram`.

The motivation behind using a generic argument was to preserve as much detailed information as possible. `Duration` can be more precise than `Double`. However in the grand scheme of things we now believe that this is overkill for a `Histogram` and a simpler to use `Histogram` type is more valuable than the lost precision. Thus this patch removes the generic argument from `Histogram`.