### PR TITLE
Fix: MetricSystem => MetricsSystem

### DIFF
--- a/Sources/Prometheus/Docs.docc/swift-metrics.md
+++ b/Sources/Prometheus/Docs.docc/swift-metrics.md
@@ -45,7 +45,7 @@ import Prometheus
 
 func main() {
   let factory = PrometheusMetricsFactory()
-  MetricSystem.bootstrap(factory)
+  MetricsSystem.bootstrap(factory)
 
   // the rest of your application code
 }
@@ -66,7 +66,7 @@ To use a different collector registry pass your ``PrometheusCollectorRegistry`` 
 ```swift
 let registry = PrometheusCollectorRegistry()
 let factory = PrometheusMetricsFactory(registry: registry)
-MetricSystem.bootstrap(factory)
+MetricsSystem.bootstrap(factory)
 ```
 
 You can also overwrite the ``PrometheusMetricsFactory/registry`` by setting it explicitly:
@@ -75,7 +75,7 @@ You can also overwrite the ``PrometheusMetricsFactory/registry`` by setting it e
 let registry = PrometheusCollectorRegistry()
 var factory = PrometheusMetricsFactory()
 factory.registry = registry
-MetricSystem.bootstrap(factory)
+MetricsSystem.bootstrap(factory)
 ```
 
 ### Modifying Swift metrics names and labels
@@ -93,7 +93,7 @@ factory.nameAndLabelSanitizer = { (name, labels)
     return (name, labels)
   }
 }
-MetricSystem.bootstrap(factory)
+MetricsSystem.bootstrap(factory)
 
 // somewhere else
 Metrics.Counter(label: "my_counter") // will show up in Prometheus exports as `counter`
@@ -134,7 +134,7 @@ factory.defaultValueHistogramBuckets = [
   100,
   250,
 ]
-MetricSystem.bootstrap(factory)
+MetricsSystem.bootstrap(factory)
 
 // somewhere else
 Timer(label: "my_timer") // will use the buckets specified in `defaultDurationHistogramBuckets`


### PR DESCRIPTION
When following the document to integrate with swift-prometheus, I found this issue:

```bash
Cannot find 'MetricSystem' in scope
```

By updating `MetricSystem` => `MetricsSystem`, this problem is fixed.