### PR TITLE
Rename unregisterTimeHistogram to unregisterDurationHistogram

### DIFF
--- a/Sources/Prometheus/PrometheusCollectorRegistry.swift
+++ b/Sources/Prometheus/PrometheusCollectorRegistry.swift
@@ -443,7 +443,7 @@ public final class PrometheusCollectorRegistry: Sendable {
     ///
     /// - Note: If the provided ``DurationHistogram`` is unknown to the registry this function call will be ignored
     /// - Parameter histogram: The ``DurationHistogram`` that shall be removed from the registry
-    public func unregisterTimeHistogram(_ histogram: DurationHistogram) {
+    public func unregisterDurationHistogram(_ histogram: DurationHistogram) {
         self.box.withLockedValue { store in
             switch store[histogram.name] {
             case .durationHistogram(let storedHistogram):

--- a/Sources/Prometheus/PrometheusMetricsFactory.swift
+++ b/Sources/Prometheus/PrometheusMetricsFactory.swift
@@ -155,6 +155,6 @@ extension PrometheusMetricsFactory: CoreMetrics.MetricsFactory {
         guard let histogram = handler as? Histogram<Duration> else {
             return
         }
-        self.registry.unregisterTimeHistogram(histogram)
+        self.registry.unregisterDurationHistogram(histogram)
     }
 }


### PR DESCRIPTION
## Motivation

The new 2.0 alpha APIs have asymmetric names for registering and unregistering duration histograms:

- `makeValueHistogram` 🙂
- `unregisterValueHistogram` 🙂
- `makeDurationHistogram` 🙂
- `unregisterTimeHistogram` 🧐

## Modifications

- Rename `unregisterTimeHistogram` to `unregisterDurationHistogram`.

## Result

APIs more symmetrically named.

## ⚠️ API breakage

This is an API breaking change and I have **not** provided a backwards compatible shim and deprecation notice, because we are currently at 2.0.0-alpha.1 and SemVer permits API breaks at this stage.

However, I'm happy to update the patch to include the temporary shim, if we want to add it now, and remove before 2.0.0 release.