### PR TITLE
Unregister the metric fully when last labelled metric is unregistered

### DIFF
--- a/Sources/Prometheus/PrometheusCollectorRegistry.swift
+++ b/Sources/Prometheus/PrometheusCollectorRegistry.swift
@@ -409,7 +409,11 @@ public final class PrometheusCollectorRegistry: Sendable {
                 let labelsKey = LabelsKey(counter.labels)
                 guard dimensions[labelsKey] === counter else { return }
                 dimensions.removeValue(forKey: labelsKey)
-                store[counter.name] = .counterWithLabels(labelNames, dimensions)
+                if dimensions.isEmpty {
+                    store.removeValue(forKey: counter.name)
+                } else {
+                    store[counter.name] = .counterWithLabels(labelNames, dimensions)
+                }
             default:
                 return
             }
@@ -431,7 +435,11 @@ public final class PrometheusCollectorRegistry: Sendable {
                 let dimensionsKey = LabelsKey(gauge.labels)
                 guard dimensions[dimensionsKey] === gauge else { return }
                 dimensions.removeValue(forKey: dimensionsKey)
-                store[gauge.name] = .gaugeWithLabels(labelNames, dimensions)
+                if dimensions.isEmpty {
+                    store.removeValue(forKey: gauge.name)
+                } else {
+                    store[gauge.name] = .gaugeWithLabels(labelNames, dimensions)
+                }
             default:
                 return
             }
@@ -453,7 +461,11 @@ public final class PrometheusCollectorRegistry: Sendable {
                 let dimensionsKey = LabelsKey(histogram.labels)
                 guard dimensions[dimensionsKey] === histogram else { return }
                 dimensions.removeValue(forKey: dimensionsKey)
-                store[histogram.name] = .durationHistogramWithLabels(labelNames, dimensions, buckets)
+                if dimensions.isEmpty {
+                    store.removeValue(forKey: histogram.name)
+                } else {
+                    store[histogram.name] = .durationHistogramWithLabels(labelNames, dimensions, buckets)
+                }
             default:
                 return
             }
@@ -475,7 +487,11 @@ public final class PrometheusCollectorRegistry: Sendable {
                 let dimensionsKey = LabelsKey(histogram.labels)
                 guard dimensions[dimensionsKey] === histogram else { return }
                 dimensions.removeValue(forKey: dimensionsKey)
-                store[histogram.name] = .valueHistogramWithLabels(labelNames, dimensions, buckets)
+                if dimensions.isEmpty {
+                    store.removeValue(forKey: histogram.name)
+                } else {
+                    store[histogram.name] = .valueHistogramWithLabels(labelNames, dimensions, buckets)
+                }
             default:
                 return
             }

--- a/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
+++ b/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
@@ -231,4 +231,34 @@ final class PrometheusCollectorRegistryTests: XCTestCase {
         )
     }
 
+    func testUnregisterReregisterWithoutLabels() {
+        let registry = PrometheusCollectorRegistry()
+        registry.unregisterCounter(registry.makeCounter(name: "name"))
+        registry.unregisterGauge(registry.makeGauge(name: "name"))
+        registry.unregisterDurationHistogram(registry.makeDurationHistogram(name: "name", buckets: []))
+        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", buckets: []))
+        _ = registry.makeCounter(name: "name")
+    }
+
+    func testUnregisterReregisterWithLabels() {
+        let registry = PrometheusCollectorRegistry()
+
+        registry.unregisterCounter(registry.makeCounter(name: "name", labels: [("a", "1")]))
+        registry.unregisterCounter(registry.makeCounter(name: "name", labels: [("b", "1")]))
+
+        registry.unregisterGauge(registry.makeGauge(name: "name", labels: [("a", "1")]))
+        registry.unregisterGauge(registry.makeGauge(name: "name", labels: [("b", "1")]))
+
+        registry.unregisterDurationHistogram(
+            registry.makeDurationHistogram(name: "name", labels: [("a", "1")], buckets: [])
+        )
+        registry.unregisterDurationHistogram(
+            registry.makeDurationHistogram(name: "name", labels: [("b", "1")], buckets: [])
+        )
+
+        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", labels: [("a", "1")], buckets: []))
+        registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", labels: [("b", "1")], buckets: []))
+
+        _ = registry.makeCounter(name: "name", labels: [("a", "1")])
+    }
 }

--- a/Tests/PrometheusTests/PrometheusMetricsFactoryTests.swift
+++ b/Tests/PrometheusTests/PrometheusMetricsFactoryTests.swift
@@ -67,8 +67,6 @@ final class PrometheusMetricsFactoryTests: XCTestCase {
         XCTAssertEqual(
             String(decoding: buffer, as: Unicode.UTF8.self),
             """
-            # TYPE foo counter
-
             """
         )
     }
@@ -126,8 +124,6 @@ final class PrometheusMetricsFactoryTests: XCTestCase {
         XCTAssertEqual(
             String(decoding: buffer, as: Unicode.UTF8.self),
             """
-            # TYPE foo gauge
-
             """
         )
     }


### PR DESCRIPTION
## Motivation

The registry is designed to return the same metric instance for a previously registered metric with the same name if, and only if:
- the metric type matches;
- the metric label _keys_ match (it's fine for the labels to differ); and
- in the case of histograms, the buckets match.

By design, it throws a fatal error if these conditions do not hold for the metric name.

However, the registry also provides methods for unregistering metrics, such that they will not be emitted. A consequence of this unregistration is it allows for the metric name to be reused:

```swift
registry.unregisterCounter(registry.makeCounter(name: "name"))
_ = registry.makeGauge(name: "name") // does not crash
```

But the API has some unexpected behaviour when unregistering metrics that were registered with labels:

```swift
registry.unregisterCounter(registry.makeCounter(name: "name", labels: [("a", "1")]))
_ = registry.makeCounter(name: "name", labels: [("b", "1")])  // crashes
```

This is because the unregister APIs currently only remove the dimensions but do not go as far as to unregister the whole metric once the last such dimension has been unregistered.

## Modifications

- Unregister the metric fully when last labelled metric is unregistered
- Add test, `testUnregisterReregisterWithoutLabels`, which passed before this patch.
- Add test, `testUnregisterReregisterWithLabels`, which failed before this patch, but now passes.

## Result

Unregistering a metric with a label will unregister the metric name if this was the only remaining dimension for that metric.