### PR TITLE
Add missing call to label customization closure for meter

### DIFF
--- a/Sources/Prometheus/PrometheusMetricsFactory.swift
+++ b/Sources/Prometheus/PrometheusMetricsFactory.swift
@@ -110,6 +110,7 @@ extension PrometheusMetricsFactory: CoreMetrics.MetricsFactory {
     }
 
     public func makeMeter(label: String, dimensions: [(String, String)]) -> CoreMetrics.MeterHandler {
+        let (label, dimensions) = self.nameAndLabelSanitizer(label, dimensions)
         return self.registry.makeGauge(name: label, labels: dimensions)
     }
 


### PR DESCRIPTION
## Motivation

The `PrometheusMetricsFactory` has a `nameAndLabelSanitizer` closure property to customize the name and labels used by callers of the Swift Metrics API. This wasn't being called in `makeMeter`.

## Modifications

Call `nameAndLabelSanitzer` in `makeMeter`, like in the other factory methods.

## Result

All factory methods use the customization closure, `nameAndLabelSanitizer`.