### PR TITLE
Enable strict concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftPrometheus open source project
@@ -44,3 +44,9 @@ let package = Package(
         ),
     ]
 )
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
+    target.swiftSettings = settings
+}


### PR DESCRIPTION
## Summary

Catch potential data races at build time.

- Enabled strict concurrency checking in the Package.swift.
- The package is warning-free with this setting out of the box, so no action.

## Test Plan

Verified no warnings and tests pass locally on macOS, and then on Linux with 5.9, 5.10, and 6.0
