### PR TITLE
Correct license headers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,9 +8,6 @@ jobs:
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
-    with:
-      license_header_check_project_name: "SwiftPrometheus"
-      license_header_check_enabled: false
 
   unit-tests:
     name: Unit tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
       license_header_check_project_name: "SwiftPrometheus"
+      license_header_check_enabled: false
 
   unit-tests:
     name: Unit tests

--- a/.license_header_template
+++ b/.license_header_template
@@ -1,0 +1,13 @@
+@@===----------------------------------------------------------------------===@@
+@@
+@@ This source file is part of the SwiftPrometheus open source project
+@@
+@@ Copyright (c) YEARS the SwiftPrometheus project authors
+@@ Licensed under Apache License v2.0
+@@
+@@ See LICENSE.txt for license information
+@@ See CONTRIBUTORS.txt for the list of SwiftPrometheus project authors
+@@
+@@ SPDX-License-Identifier: Apache-2.0
+@@
+@@===----------------------------------------------------------------------===@@

--- a/.license_header_template
+++ b/.license_header_template
@@ -2,7 +2,7 @@
 @@
 @@ This source file is part of the SwiftPrometheus open source project
 @@
-@@ Copyright (c) YEARS the SwiftPrometheus project authors
+@@ Copyright (c) YEARS SwiftPrometheus project authors
 @@ Licensed under Apache License v2.0
 @@
 @@ See LICENSE.txt for license information

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2025 the SwiftPrometheus project authors
+// Copyright (c) 2018-2025 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-$§ Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2025 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/Counter.swift
+++ b/Sources/Prometheus/Counter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/Counter.swift
+++ b/Sources/Prometheus/Counter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/Gauge.swift
+++ b/Sources/Prometheus/Gauge.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/Gauge.swift
+++ b/Sources/Prometheus/Gauge.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/Histogram.swift
+++ b/Sources/Prometheus/Histogram.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/Histogram.swift
+++ b/Sources/Prometheus/Histogram.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/NIOLock.swift
+++ b/Sources/Prometheus/NIOLock.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2023 the SwiftPrometheus project authors
+// Copyright (c) 2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/NIOLock.swift
+++ b/Sources/Prometheus/NIOLock.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/NIOLockedValueBox.swift
+++ b/Sources/Prometheus/NIOLockedValueBox.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2023 the SwiftPrometheus project authors
+// Copyright (c) 2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/NIOLockedValueBox.swift
+++ b/Sources/Prometheus/NIOLockedValueBox.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/PrometheusCollectorRegistry.swift
+++ b/Sources/Prometheus/PrometheusCollectorRegistry.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/PrometheusCollectorRegistry.swift
+++ b/Sources/Prometheus/PrometheusCollectorRegistry.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/PrometheusMetricsFactory.swift
+++ b/Sources/Prometheus/PrometheusMetricsFactory.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Prometheus/PrometheusMetricsFactory.swift
+++ b/Sources/Prometheus/PrometheusMetricsFactory.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/CounterTests.swift
+++ b/Tests/PrometheusTests/CounterTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/CounterTests.swift
+++ b/Tests/PrometheusTests/CounterTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/GaugeTests.swift
+++ b/Tests/PrometheusTests/GaugeTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/GaugeTests.swift
+++ b/Tests/PrometheusTests/GaugeTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/HistogramTests.swift
+++ b/Tests/PrometheusTests/HistogramTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/HistogramTests.swift
+++ b/Tests/PrometheusTests/HistogramTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
+++ b/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
+++ b/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/PrometheusMetricsFactoryTests.swift
+++ b/Tests/PrometheusTests/PrometheusMetricsFactoryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/PrometheusMetricsFactoryTests.swift
+++ b/Tests/PrometheusTests/PrometheusMetricsFactoryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2018-2023 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2018-2023 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/ValidNamesTests.swift
+++ b/Tests/PrometheusTests/ValidNamesTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2024 the SwiftPrometheus project authors
+// Copyright (c) 2024 SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/PrometheusTests/ValidNamesTests.swift
+++ b/Tests/PrometheusTests/ValidNamesTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftPrometheus open source project
 //
-// Copyright (c) 2024 Apple Inc. and the SwiftPrometheus project authors
+// Copyright (c) 2024 the SwiftPrometheus project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information


### PR DESCRIPTION
### Motivation:

To correct the license header changes made as part of #117.

### Modifications:

* Revert license header changes
* License header checks use custom `.license_header_template`

### Result:

Correct license headers.