### PR TITLE
inline histogram record (gives 10x boost)

### DIFF
--- a/Sources/Prometheus/Histogram.swift
+++ b/Sources/Prometheus/Histogram.swift
@@ -56,6 +56,7 @@ public final class Histogram<Value: Bucketable>: Sendable {
         self.box = .init(.init(buckets: buckets))
     }
 
+    @inlinable
     public func record(_ value: Value) {
         self.box.withLockedValue { state in
             for i in state.buckets.startIndex..<state.buckets.endIndex {


### PR DESCRIPTION
Before inlining:
```
====================
PrometheusBenchmarks
====================

DurationHistogram
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions *                │      3213 │      3215 │      3215 │      3217 │      3219 │      3432 │      3452 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) *              │         0 │         0 │         0 │         0 │         0 │         0 │         0 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (K)    │      8421 │      8757 │      8774 │      8790 │      8798 │      8798 │      8798 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (K)        │      4556 │      4135 │      4009 │      3877 │      3765 │      3569 │      3272 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (ns) *       │       221 │       244 │       252 │       260 │       268 │       282 │       307 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ns) *      │       220 │       242 │       249 │       258 │       266 │       280 │       306 │     10000 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```

After inlining:
```
====================
PrometheusBenchmarks
====================

DurationHistogram
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions *                │       281 │       281 │       281 │       281 │       281 │       283 │       299 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) *              │         0 │         0 │         0 │         0 │         0 │         0 │         0 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (K)    │      8405 │      8724 │      8741 │      8757 │      8765 │      8765 │      8765 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (M)        │        53 │        51 │        51 │        48 │        42 │        36 │        26 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (ns) *       │        20 │        21 │        22 │        23 │        26 │        30 │        40 │     10000 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ns) *      │        19 │        20 │        20 │        21 │        24 │        28 │        39 │     10000 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```

Used cherry pick benchmarks from this PR: https://github.com/swift-server/swift-prometheus/pull/106