### PR TITLE
refactor[Histograms]: uniquely identify metric time series by name and label sets (2/2)

### DIFF
--- a/Sources/Prometheus/PrometheusCollectorRegistry.swift
+++ b/Sources/Prometheus/PrometheusCollectorRegistry.swift
@@ -52,7 +52,7 @@ public final class PrometheusCollectorRegistry: Sendable {
         let help: String
     }
 
-    private enum BucketType: Sendable, Hashable {
+    private enum HistogramBuckets: Sendable, Hashable {
         case duration([Duration])
         case value([Double])
     }
@@ -66,16 +66,11 @@ public final class PrometheusCollectorRegistry: Sendable {
     /// metric. See also https://github.com/prometheus/OpenMetrics/issues/197.
     private struct MetricGroup<Metric: Sendable & AnyObject>: Sendable {
         var metricsByLabelSets: [LabelsKey: MetricWithHelp<Metric>]
-        let buckets: BucketType?  // Store buckets for histogram types
+        let buckets: HistogramBuckets?
 
-        init(metricsByLabelSets: [LabelsKey: MetricWithHelp<Metric>] = [:], buckets: BucketType) {
+        init(metricsByLabelSets: [LabelsKey: MetricWithHelp<Metric>] = [:], buckets: HistogramBuckets? = nil) {
             self.metricsByLabelSets = metricsByLabelSets
             self.buckets = buckets
-        }
-
-        init(metricsByLabelSets: [LabelsKey: MetricWithHelp<Metric>] = [:]) {
-            self.metricsByLabelSets = metricsByLabelSets
-            self.buckets = nil
         }
     }
 


### PR DESCRIPTION
refactor: uniquely identify {Value,Duration}Histograms by name and label sets
    
Previously, {Value,Duration}Histograms could only be identified by their name. This change allows multiple {Value,Duration}Histograms to share the same name, with each unique set of labels defining a distinct time series.

However, the buckets are immutable for a MetricGroup once initialized with the first metric.

Additionally, the internal data structure for a stored metric has been refactored, providing a more robust and programmatic representation.

CC @ktoso @FranzBusch 


Follow for https://github.com/swift-server/swift-prometheus/pull/131, fixes https://github.com/swift-server/swift-prometheus/issues/125