### PR TITLE
feat: add {emitToString, emitToBuffer} options + dedup TYPE and HELP per metric name

### DIFF
--- a/Tests/PrometheusTests/CounterTests.swift
+++ b/Tests/PrometheusTests/CounterTests.swift
@@ -171,19 +171,19 @@ final class CounterTests: XCTestCase {
         let counter0 = client.makeCounter(
             name: "foo",
             labels: [],
-            help: "Base metric name with no labels"
+            help: "Shared help text"
         )
 
         let counter1 = client.makeCounter(
             name: "foo",
             labels: [("bar", "baz")],
-            help: "Base metric name with one label set variant"
+            help: "Shared help text"
         )
 
         let counter2 = client.makeCounter(
             name: "foo",
             labels: [("bar", "newBaz"), ("newKey1", "newValue1")],
-            help: "Base metric name with a different label set variant"
+            help: "Shared help text"
         )
 
         var buffer = [UInt8]()
@@ -197,16 +197,12 @@ final class CounterTests: XCTestCase {
         var outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         var actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         var expectedLines = Set([
-            "# HELP foo Base metric name with no labels",
+            "# HELP foo Shared help text",
             "# TYPE foo counter",
             "foo 2",
 
-            "# HELP foo Base metric name with one label set variant",
-            "# TYPE foo counter",
             #"foo{bar="baz"} 12"#,
 
-            "# HELP foo Base metric name with a different label set variant",
-            "# TYPE foo counter",
             #"foo{bar="newBaz",newKey1="newValue1"} 24"#,
         ])
         XCTAssertEqual(actualLines, expectedLines)
@@ -218,12 +214,10 @@ final class CounterTests: XCTestCase {
         outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         expectedLines = Set([
-            "# HELP foo Base metric name with one label set variant",
+            "# HELP foo Shared help text",
             "# TYPE foo counter",
             #"foo{bar="baz"} 12"#,
 
-            "# HELP foo Base metric name with a different label set variant",
-            "# TYPE foo counter",
             #"foo{bar="newBaz",newKey1="newValue1"} 24"#,
         ])
         XCTAssertEqual(actualLines, expectedLines)
@@ -234,7 +228,7 @@ final class CounterTests: XCTestCase {
         outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         expectedLines = Set([
-            "# HELP foo Base metric name with a different label set variant",
+            "# HELP foo Shared help text",
             "# TYPE foo counter",
             #"foo{bar="newBaz",newKey1="newValue1"} 24"#,
         ])
@@ -251,14 +245,14 @@ final class CounterTests: XCTestCase {
         let _ = client.makeGauge(
             name: "foo",
             labels: [],
-            help: "Base metric name used for new metric of type gauge"
+            help: "Shared help text"
         )
         buffer.removeAll(keepingCapacity: true)
         client.emit(into: &buffer)
         XCTAssertEqual(
             String(decoding: buffer, as: Unicode.UTF8.self),
             """
-            # HELP foo Base metric name used for new metric of type gauge
+            # HELP foo Shared help text
             # TYPE foo gauge
             foo 0.0
 

--- a/Tests/PrometheusTests/GaugeTests.swift
+++ b/Tests/PrometheusTests/GaugeTests.swift
@@ -158,19 +158,19 @@ final class GaugeTests: XCTestCase {
         let gauge0 = client.makeGauge(
             name: "foo",
             labels: [],
-            help: "Base metric name with no labels"
+            help: "Shared help text"
         )
 
         let gauge1 = client.makeGauge(
             name: "foo",
             labels: [("bar", "baz")],
-            help: "Base metric name with one label set variant"
+            help: "Shared help text"
         )
 
         let gauge2 = client.makeGauge(
             name: "foo",
             labels: [("bar", "newBaz"), ("newKey1", "newValue1")],
-            help: "Base metric name with a different label set variant"
+            help: "Shared help text"
         )
 
         var buffer = [UInt8]()
@@ -184,16 +184,12 @@ final class GaugeTests: XCTestCase {
         var outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         var actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         var expectedLines = Set([
-            "# HELP foo Base metric name with no labels",
+            "# HELP foo Shared help text",
             "# TYPE foo gauge",
             "foo 2.0",
 
-            "# HELP foo Base metric name with one label set variant",
-            "# TYPE foo gauge",
             #"foo{bar="baz"} -3.0"#,
 
-            "# HELP foo Base metric name with a different label set variant",
-            "# TYPE foo gauge",
             #"foo{bar="newBaz",newKey1="newValue1"} 28.0"#,
         ])
         XCTAssertEqual(actualLines, expectedLines)
@@ -205,12 +201,10 @@ final class GaugeTests: XCTestCase {
         outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         expectedLines = Set([
-            "# HELP foo Base metric name with one label set variant",
+            "# HELP foo Shared help text",
             "# TYPE foo gauge",
             #"foo{bar="baz"} -3.0"#,
 
-            "# HELP foo Base metric name with a different label set variant",
-            "# TYPE foo gauge",
             #"foo{bar="newBaz",newKey1="newValue1"} 28.0"#,
         ])
         XCTAssertEqual(actualLines, expectedLines)
@@ -221,7 +215,7 @@ final class GaugeTests: XCTestCase {
         outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         expectedLines = Set([
-            "# HELP foo Base metric name with a different label set variant",
+            "# HELP foo Shared help text",
             "# TYPE foo gauge",
             #"foo{bar="newBaz",newKey1="newValue1"} 28.0"#,
         ])
@@ -238,14 +232,14 @@ final class GaugeTests: XCTestCase {
         let _ = client.makeCounter(
             name: "foo",
             labels: [],
-            help: "Base metric name used for new metric of type counter"
+            help: "Shared help text"
         )
         buffer.removeAll(keepingCapacity: true)
         client.emit(into: &buffer)
         XCTAssertEqual(
             String(decoding: buffer, as: Unicode.UTF8.self),
             """
-            # HELP foo Base metric name used for new metric of type counter
+            # HELP foo Shared help text
             # TYPE foo counter
             foo 0
 

--- a/Tests/PrometheusTests/HistogramTests.swift
+++ b/Tests/PrometheusTests/HistogramTests.swift
@@ -385,21 +385,21 @@ final class HistogramTests: XCTestCase {
             name: "foo",
             labels: [],
             buckets: sharedBuckets,
-            help: "Base metric name with no labels"
+            help: "Shared help text"
         )
 
         let histogram1 = client.makeDurationHistogram(
             name: "foo",
             labels: [("bar", "baz")],
             buckets: sharedBuckets,  // Must match the first registration
-            help: "Base metric name with one label set variant"
+            help: "Shared help text"
         )
 
         let histogram2 = client.makeDurationHistogram(
             name: "foo",
             labels: [("bar", "newBaz"), ("newKey1", "newValue1")],
             buckets: sharedBuckets,  // Must match the first registration
-            help: "Base metric name with a different label set variant"
+            help: "Shared help text"
         )
 
         var buffer = [UInt8]()
@@ -414,7 +414,7 @@ final class HistogramTests: XCTestCase {
         var outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         var actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         var expectedLines = Set([
-            "# HELP foo Base metric name with no labels",
+            "# HELP foo Shared help text",
             "# TYPE foo histogram",
             "foo_bucket{le=\"0.1\"} 0",
             "foo_bucket{le=\"0.5\"} 1",
@@ -423,8 +423,6 @@ final class HistogramTests: XCTestCase {
             "foo_sum 1.1",
             "foo_count 2",
 
-            "# HELP foo Base metric name with one label set variant",
-            "# TYPE foo histogram",
             #"foo_bucket{bar="baz",le="0.1"} 0"#,
             #"foo_bucket{bar="baz",le="0.5"} 0"#,
             #"foo_bucket{bar="baz",le="1.0"} 1"#,
@@ -432,8 +430,6 @@ final class HistogramTests: XCTestCase {
             #"foo_sum{bar="baz"} 2.1"#,
             #"foo_count{bar="baz"} 2"#,
 
-            "# HELP foo Base metric name with a different label set variant",
-            "# TYPE foo histogram",
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="0.1"} 1"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="0.5"} 2"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="1.0"} 2"#,
@@ -450,7 +446,7 @@ final class HistogramTests: XCTestCase {
         outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         expectedLines = Set([
-            "# HELP foo Base metric name with one label set variant",
+            "# HELP foo Shared help text",
             "# TYPE foo histogram",
             #"foo_bucket{bar="baz",le="0.1"} 0"#,
             #"foo_bucket{bar="baz",le="0.5"} 0"#,
@@ -459,8 +455,6 @@ final class HistogramTests: XCTestCase {
             #"foo_sum{bar="baz"} 2.1"#,
             #"foo_count{bar="baz"} 2"#,
 
-            "# HELP foo Base metric name with a different label set variant",
-            "# TYPE foo histogram",
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="0.1"} 1"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="0.5"} 2"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="1.0"} 2"#,
@@ -476,7 +470,7 @@ final class HistogramTests: XCTestCase {
         outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         expectedLines = Set([
-            "# HELP foo Base metric name with a different label set variant",
+            "# HELP foo Shared help text",
             "# TYPE foo histogram",
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="0.1"} 1"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="0.5"} 2"#,
@@ -498,14 +492,14 @@ final class HistogramTests: XCTestCase {
         let _ = client.makeGauge(
             name: "foo",
             labels: [],
-            help: "Base metric name used for new metric of type gauge"
+            help: "Shared help text"
         )
         buffer.removeAll(keepingCapacity: true)
         client.emit(into: &buffer)
         XCTAssertEqual(
             String(decoding: buffer, as: Unicode.UTF8.self),
             """
-            # HELP foo Base metric name used for new metric of type gauge
+            # HELP foo Shared help text
             # TYPE foo gauge
             foo 0.0
 
@@ -525,21 +519,21 @@ final class HistogramTests: XCTestCase {
             name: "foo",
             labels: [],
             buckets: sharedBuckets,
-            help: "Base metric name with no labels"
+            help: "Shared help text"
         )
 
         let histogram1 = client.makeValueHistogram(
             name: "foo",
             labels: [("bar", "baz")],
             buckets: sharedBuckets,  // Must match the first registration
-            help: "Base metric name with one label set variant"
+            help: "Shared help text"
         )
 
         let histogram2 = client.makeValueHistogram(
             name: "foo",
             labels: [("bar", "newBaz"), ("newKey1", "newValue1")],
             buckets: sharedBuckets,  // Must match the first registration
-            help: "Base metric name with a different label set variant"
+            help: "Shared help text"
         )
 
         var buffer = [UInt8]()
@@ -554,7 +548,7 @@ final class HistogramTests: XCTestCase {
         var outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         var actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         var expectedLines = Set([
-            "# HELP foo Base metric name with no labels",
+            "# HELP foo Shared help text",
             "# TYPE foo histogram",
             "foo_bucket{le=\"1.0\"} 0",
             "foo_bucket{le=\"5.0\"} 1",
@@ -563,8 +557,6 @@ final class HistogramTests: XCTestCase {
             "foo_sum 11.0",
             "foo_count 2",
 
-            "# HELP foo Base metric name with one label set variant",
-            "# TYPE foo histogram",
             #"foo_bucket{bar="baz",le="1.0"} 0"#,
             #"foo_bucket{bar="baz",le="5.0"} 0"#,
             #"foo_bucket{bar="baz",le="10.0"} 1"#,
@@ -572,8 +564,6 @@ final class HistogramTests: XCTestCase {
             #"foo_sum{bar="baz"} 18.0"#,
             #"foo_count{bar="baz"} 2"#,
 
-            "# HELP foo Base metric name with a different label set variant",
-            "# TYPE foo histogram",
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="1.0"} 0"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="5.0"} 2"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="10.0"} 2"#,
@@ -590,7 +580,7 @@ final class HistogramTests: XCTestCase {
         outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         expectedLines = Set([
-            "# HELP foo Base metric name with one label set variant",
+            "# HELP foo Shared help text",
             "# TYPE foo histogram",
             #"foo_bucket{bar="baz",le="1.0"} 0"#,
             #"foo_bucket{bar="baz",le="5.0"} 0"#,
@@ -599,8 +589,6 @@ final class HistogramTests: XCTestCase {
             #"foo_sum{bar="baz"} 18.0"#,
             #"foo_count{bar="baz"} 2"#,
 
-            "# HELP foo Base metric name with a different label set variant",
-            "# TYPE foo histogram",
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="1.0"} 0"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="5.0"} 2"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="10.0"} 2"#,
@@ -616,7 +604,7 @@ final class HistogramTests: XCTestCase {
         outputString = String(decoding: buffer, as: Unicode.UTF8.self)
         actualLines = Set(outputString.components(separatedBy: .newlines).filter { !$0.isEmpty })
         expectedLines = Set([
-            "# HELP foo Base metric name with a different label set variant",
+            "# HELP foo Shared help text",
             "# TYPE foo histogram",
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="1.0"} 0"#,
             #"foo_bucket{bar="newBaz",newKey1="newValue1",le="5.0"} 2"#,
@@ -638,14 +626,14 @@ final class HistogramTests: XCTestCase {
         let _ = client.makeGauge(
             name: "foo",
             labels: [],
-            help: "Base metric name used for new metric of type gauge"
+            help: "Shared help text"
         )
         buffer.removeAll(keepingCapacity: true)
         client.emit(into: &buffer)
         XCTAssertEqual(
             String(decoding: buffer, as: Unicode.UTF8.self),
             """
-            # HELP foo Base metric name used for new metric of type gauge
+            # HELP foo Shared help text
             # TYPE foo gauge
             foo 0.0
 

--- a/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
+++ b/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
@@ -439,14 +439,8 @@ final class PrometheusCollectorRegistryTests: XCTestCase {
         XCTAssertEqual(emptyCapacity, 0)
     }
 
-    func testDefaultRegistryDedupTypeHelpPerMetricNameOnEmitWhenMetricNameSharedInMetricGroup() {
+    func testDefaultRegistryDedupTypeHelpPerMetricNameOnEmitWhenMetricNameSharedInMetricFamily() {
         let client = PrometheusCollectorRegistry()
-
-        let gauge0 = client.makeGauge(
-            name: "foo",
-            labels: [],
-            help: "Shared help text for all variants"
-        )
 
         let gauge1 = client.makeGauge(
             name: "foo",
@@ -460,7 +454,6 @@ final class PrometheusCollectorRegistryTests: XCTestCase {
             help: "Shared help text for all variants"
         )
 
-        gauge0.set(to: 1.0)
         gauge1.set(to: 9.0)
         gauge2.set(to: 4.0)
 
@@ -476,7 +469,7 @@ final class PrometheusCollectorRegistryTests: XCTestCase {
 
         XCTAssertEqual(helpLines.count, 1, "Should have exactly one HELP line")
         XCTAssertEqual(typeLines.count, 1, "Should have exactly one TYPE line")
-        XCTAssertEqual(metricLines.count, 3, "Should have three metric value lines")
+        XCTAssertEqual(metricLines.count, 2, "Should have three metric value lines")
 
         XCTAssertEqual(helpLines.first, "# HELP foo Shared help text for all variants")
         XCTAssertEqual(typeLines.first, "# TYPE foo gauge")
@@ -490,7 +483,6 @@ final class PrometheusCollectorRegistryTests: XCTestCase {
         XCTAssertLessThan(typeIndex, firstMetricIndex, "TYPE should appear before metric values")
 
         // Verify all three metric values are present (order doesn't matter).
-        XCTAssertTrue(metricLines.contains("foo 1.0"))
         XCTAssertTrue(metricLines.contains(#"foo{bar="baz"} 9.0"#))
         XCTAssertTrue(metricLines.contains(#"foo{bar="newBaz",newKey1="newValue1"} 4.0"#))
     }

--- a/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
+++ b/Tests/PrometheusTests/PrometheusCollectorRegistryTests.swift
@@ -261,4 +261,238 @@ final class PrometheusCollectorRegistryTests: XCTestCase {
 
         _ = registry.makeCounter(name: "name", labels: [("a", "1")])
     }
+
+    func testInternalBufferEmitToStringEmitToBuffer() {
+        let client = PrometheusCollectorRegistry()
+
+        // Initially, buffer should have no capacity
+        XCTAssertEqual(client.internalBufferCapacity(), 0)
+
+        // Create some metrics to establish buffer size.
+        let gauge1 = client.makeGauge(name: "test_gauge_1", labels: [])
+        let gauge2 = client.makeGauge(name: "test_gauge_2", labels: [("label", "value")])
+        let counter = client.makeCounter(name: "test_counter", labels: [])
+
+        gauge1.set(42.0)
+        gauge2.set(100.0)
+        counter.increment(by: 5.0)
+
+        // First emission - start with emitToBuffer (this will auto-size the internal buffer).
+        let output1Buffer = client.emitToBuffer()
+        let output1String = client.emitToString()
+
+        XCTAssertFalse(output1String.isEmpty)
+        XCTAssertFalse(output1Buffer.isEmpty)
+
+        // Verify both outputs represent the same data.
+        XCTAssertEqual(output1String, String(decoding: output1Buffer, as: UTF8.self))
+
+        // Buffer should now have some capacity.
+        let initialCapacity = client.internalBufferCapacity()
+        XCTAssertGreaterThan(initialCapacity, 0)
+
+        // Second emission - start with emitToString this time.
+        let output2String = client.emitToString()
+        let output2Buffer = client.emitToBuffer()
+
+        // Same content regardless of method used.
+        XCTAssertEqual(output1String, output2String)
+        XCTAssertEqual(output1Buffer, output2Buffer)
+        XCTAssertEqual(output2String, String(decoding: output2Buffer, as: UTF8.self))
+        XCTAssertEqual(client.internalBufferCapacity(), initialCapacity)  // Same capacity
+
+        // Reset the internal buffer.
+        client.resetInternalBuffer()
+        XCTAssertEqual(client.internalBufferCapacity(), 0)  // Capacity should be reset to 0
+
+        // Add more metrics to change the required buffer size.
+        let histogram = client.makeValueHistogram(
+            name: "test_histogram",
+            labels: [("method", "GET"), ("status", "200")],
+            buckets: [0.1, 0.5, 1.0, 5.0, 10.0]
+        )
+        histogram.record(2.5)
+
+        // This emission should re-calibrate the buffer size - start with emitToString.
+        let output3String = client.emitToString()
+        let output3Buffer = client.emitToBuffer()
+
+        XCTAssertTrue(output3String.contains("test_histogram"))
+        XCTAssertTrue(output3String.contains("test_gauge_1"))
+        XCTAssertEqual(output3String, String(decoding: output3Buffer, as: UTF8.self))
+
+        // Buffer should have a new capacity after re-calibration.
+        let recalibratedCapacity = client.internalBufferCapacity()
+        XCTAssertGreaterThan(recalibratedCapacity, 0)
+        XCTAssertGreaterThan(recalibratedCapacity, initialCapacity)
+
+        // Add many more metrics after re-calibration to force buffer resizing.
+        // Add multiple gauges with long names and labels to increase buffer requirements.
+        var additionalGauges: [Gauge] = []
+        for i in 0..<10 {
+            let gauge = client.makeGauge(
+                name: "test_gauge_with_very_long_name_to_increase_buffer_size_\(i)",
+                labels: [
+                    ("environment", "production_environment_with_long_value"),
+                    ("service", "microservice_with_extremely_long_service_name"),
+                    ("region", "us-west-2-availability-zone-1a-with-long-suffix"),
+                    ("version", "v1.2.3-build-12345-commit-abcdef123456789"),
+                ]
+            )
+            gauge.set(Double(i * 100))
+            additionalGauges.append(gauge)
+        }
+
+        // Add multiple counters with extensive labels.
+        var additionalCounters: [Counter] = []
+        for i in 0..<5 {
+            let counter = client.makeCounter(
+                name: "http_requests_total_with_very_descriptive_name_\(i)",
+                labels: [
+                    ("method", "POST"),
+                    ("endpoint", "/api/v1/users/profile/settings/notifications/preferences"),
+                    ("status_code", "200"),
+                    ("user_agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"),
+                    ("client_ip", "192.168.1.100"),
+                    ("request_id", "req-\(UUID().uuidString)"),
+                ]
+            )
+            counter.increment(by: Double(i + 1) * 50)
+            additionalCounters.append(counter)
+        }
+
+        // Add multiple histograms with many buckets.
+        var additionalHistograms: [ValueHistogram] = []
+        for i in 0..<3 {
+            let histogram = client.makeValueHistogram(
+                name: "request_duration_seconds_detailed_histogram_\(i)",
+                labels: [
+                    ("service", "authentication-service-with-long-name"),
+                    ("operation", "validate-user-credentials-and-permissions"),
+                    ("database", "postgresql-primary-read-write-instance"),
+                ],
+                buckets: [
+                    0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 15.0, 20.0,
+                    30.0,
+                ]
+            )
+            for j in 0..<20 {
+                histogram.record(Double(j) * 0.1 + Double(i))
+            }
+            additionalHistograms.append(histogram)
+        }
+
+        // This should definitely trigger buffer resizing due to massive amount of new content.
+        let output4String = client.emitToString()
+        let output4Buffer = client.emitToBuffer()
+
+        XCTAssertTrue(output4String.contains("test_histogram"))
+        XCTAssertTrue(output4String.contains("test_gauge_with_very_long_name"))
+        XCTAssertTrue(output4String.contains("http_requests_total_with_very_descriptive_name"))
+        XCTAssertTrue(output4String.contains("request_duration_seconds_detailed_histogram"))
+        XCTAssertEqual(output4String, String(decoding: output4Buffer, as: UTF8.self))
+
+        // Buffer capacity should have grown significantly to accommodate all the additional metrics.
+        let newCapacity = client.internalBufferCapacity()
+        XCTAssertGreaterThan(newCapacity, 0)
+        XCTAssertGreaterThan(newCapacity, recalibratedCapacity)  // Should be much larger now
+
+        // Subsequent emission should reuse the new buffer size - start with emitToBuffer.
+        let output5Buffer = client.emitToBuffer()
+        let output5String = client.emitToString()
+
+        XCTAssertEqual(output4String, output5String)
+        XCTAssertEqual(output4Buffer, output5Buffer)
+        XCTAssertEqual(output5String, String(decoding: output5Buffer, as: UTF8.self))
+        XCTAssertEqual(client.internalBufferCapacity(), newCapacity)  // Capacity unchanged
+
+        // Verify buffer reset works with empty registry - unregister all metrics
+        client.unregisterGauge(gauge1)
+        client.unregisterGauge(gauge2)
+        client.unregisterCounter(counter)
+        client.unregisterValueHistogram(histogram)
+
+        // Unregister all additional metrics.
+        for gauge in additionalGauges {
+            client.unregisterGauge(gauge)
+        }
+        for counter in additionalCounters {
+            client.unregisterCounter(counter)
+        }
+        for histogram in additionalHistograms {
+            client.unregisterValueHistogram(histogram)
+        }
+
+        client.resetInternalBuffer()
+        XCTAssertEqual(client.internalBufferCapacity(), 0)  // Reset to 0 again
+
+        // Test empty output with both methods - start with emitToString.
+        let emptyOutputString = client.emitToString()
+        let emptyOutputBuffer = client.emitToBuffer()
+
+        XCTAssertTrue(emptyOutputString.isEmpty)
+        XCTAssertTrue(emptyOutputBuffer.isEmpty)
+        XCTAssertEqual(emptyOutputString, String(decoding: emptyOutputBuffer, as: UTF8.self))
+
+        // With empty output, buffer capacity should remain 0.
+        let emptyCapacity = client.internalBufferCapacity()
+        XCTAssertEqual(emptyCapacity, 0)
+    }
+
+    func testDefaultRegistryDedupTypeHelpPerMetricNameOnEmitWhenMetricNameSharedInMetricGroup() {
+        let client = PrometheusCollectorRegistry()
+
+        let gauge0 = client.makeGauge(
+            name: "foo",
+            labels: [],
+            help: "Shared help text for all variants"
+        )
+
+        let gauge1 = client.makeGauge(
+            name: "foo",
+            labels: [("bar", "baz")],
+            help: "Shared help text for all variants"
+        )
+
+        let gauge2 = client.makeGauge(
+            name: "foo",
+            labels: [("bar", "newBaz"), ("newKey1", "newValue1")],
+            help: "Shared help text for all variants"
+        )
+
+        gauge0.set(to: 1.0)
+        gauge1.set(to: 9.0)
+        gauge2.set(to: 4.0)
+
+        var buffer = [UInt8]()
+        client.emit(into: &buffer)
+        let outputString = String(decoding: buffer, as: Unicode.UTF8.self)
+        let lines = outputString.components(separatedBy: .newlines).filter { !$0.isEmpty }
+
+        // Should have exactly one HELP and one TYPE line.
+        let helpLines = lines.filter { $0.hasPrefix("# HELP foo") }
+        let typeLines = lines.filter { $0.hasPrefix("# TYPE foo") }
+        let metricLines = lines.filter { $0.hasPrefix("foo") && !$0.hasPrefix("# ") }
+
+        XCTAssertEqual(helpLines.count, 1, "Should have exactly one HELP line")
+        XCTAssertEqual(typeLines.count, 1, "Should have exactly one TYPE line")
+        XCTAssertEqual(metricLines.count, 3, "Should have three metric value lines")
+
+        XCTAssertEqual(helpLines.first, "# HELP foo Shared help text for all variants")
+        XCTAssertEqual(typeLines.first, "# TYPE foo gauge")
+
+        // Verify HELP and TYPE appear before any metric values.
+        let helpIndex = lines.firstIndex { $0.hasPrefix("# HELP foo") }!
+        let typeIndex = lines.firstIndex { $0.hasPrefix("# TYPE foo") }!
+        let firstMetricIndex = lines.firstIndex { $0.hasPrefix("foo") && !$0.hasPrefix("# ") }!
+
+        XCTAssertLessThan(helpIndex, firstMetricIndex, "HELP should appear before metric values")
+        XCTAssertLessThan(typeIndex, firstMetricIndex, "TYPE should appear before metric values")
+
+        // Verify all three metric values are present (order doesn't matter).
+        XCTAssertTrue(metricLines.contains("foo 1.0"))
+        XCTAssertTrue(metricLines.contains(#"foo{bar="baz"} 9.0"#))
+        XCTAssertTrue(metricLines.contains(#"foo{bar="newBaz",newKey1="newValue1"} 4.0"#))
+    }
+
 }


### PR DESCRIPTION

Add {emitToString, emitToBuffer} thread-safe internal buffer management variants to emit metrics.

Deduplicate TYPE and HELP lines per metric name by default on emit.


Fixes https://github.com/swift-server/swift-prometheus/issues/118 @ptoffy


CC @ktoso and @FranzBusch 