### PR TITLE
Add MAINTAINERS.md file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,6 @@
+# Maintainers
+
+General maintainers:
+* Melissa Melissa (mkilby@apple.com / @incertum)
+* Konrad 'ktoso' Malawski (ktoso@apple.com / @ktoso)
+* 


### PR DESCRIPTION
It seems prometheus requires a MAINTAINERS.md file:

> Each project must have a MAINTAINERS.md file with at least one maintainer. 

It's not the same as CODEOWNERS but would be the same list of people really.

@FranzBusch @fabianfett shall we add one or either of you as well?