### PR TITLE
Make dependabot set  label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    labels:
+      - "semver/none"


### PR DESCRIPTION
Prompt: Make dependabot set  label

Claude output:
Both changes are already in place:
- **Schedule interval** is already set to `"daily"` (line 6)
- **Label `semver/none`** is already configured (lines 7-8)

The file is already correctly configured. The git status shows it as modified, so these changes were likely made before this conversation started. No further edits needed.
