### PR TITLE
feat: add FreeBSD pthread support to NIOLock

### DIFF
--- a/Sources/Prometheus/NIOLock.swift
+++ b/Sources/Prometheus/NIOLock.swift
@@ -48,6 +48,9 @@ import wasi_pthread
 #if os(Windows)
 @usableFromInline
 typealias LockPrimitive = SRWLOCK
+#elseif os(FreeBSD) || os(OpenBSD)
+@usableFromInline
+typealias LockPrimitive = pthread_mutex_t?
 #else
 @usableFromInline
 typealias LockPrimitive = pthread_mutex_t
@@ -64,11 +67,19 @@ extension LockOperations {
         #if os(Windows)
         InitializeSRWLock(mutex)
         #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        #if os(FreeBSD) || os(OpenBSD)
+        var attr = pthread_mutexattr_t(bitPattern: 0)
+        #else
         var attr = pthread_mutexattr_t()
+        #endif
         pthread_mutexattr_init(&attr)
         assert(
             {
+                #if os(FreeBSD) || os(OpenBSD)
+                pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK.rawValue))
+                #else
                 pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
+                #endif
                 return true
             }()
         )


### PR DESCRIPTION
### Motivation

`NIOLock`'s pthread fallback branch types `LockPrimitive` as
`pthread_mutex_t` and initializes `pthread_mutexattr_t` with a default
initializer; both compile on Linux but fail on FreeBSD / OpenBSD where
those types are opaque-pointer typedefs imported as
`Optional<OpaquePointer>`. Additionally, `PTHREAD_MUTEX_ERRORCHECK` is
imported as a `pthread_mutextype` enum case on FreeBSD whose `.rawValue`
must be used to construct the `CInt` that `pthread_mutexattr_settype`
expects.

This blocks swift-prometheus from compiling on FreeBSD with the
official Swift FreeBSD preview toolchain.

### Modifications

Mirror the pattern landed in [apple/swift-log#387][log-pr]; same fix is
being submitted for the sibling NIOLock copies in
[apple/swift-http-types#123][sht-pr] and
swift-server/swift-service-lifecycle:

- On `os(FreeBSD) || os(OpenBSD)` alias `LockPrimitive` to
  `pthread_mutex_t?`.
- Initialize `pthread_mutexattr_t` via the `bitPattern:` overload.
- On `os(FreeBSD) || os(OpenBSD)`, access `PTHREAD_MUTEX_ERRORCHECK`
  via `.rawValue` before passing to `pthread_mutexattr_settype`.

[log-pr]: https://github.com/apple/swift-log/pull/387
[sht-pr]: https://github.com/apple/swift-http-types/pull/123

Touches one file (`Sources/Prometheus/NIOLock.swift`), +11 lines, all
behind FreeBSD/OpenBSD conditionals. No behaviour change on existing
platforms.

### Result

`swift build` and `swift test` both clean on FreeBSD 15.0 with the
official Swift FreeBSD preview toolchain:

```
$ uname -a
FreeBSD swiftbuild 15.0-RELEASE FreeBSD 15.0-RELEASE-p9 releng/15.0-n281048-6d536196f1bd GENERIC amd64

$ swift --version
Swift version 6.3-dev (LLVM 972b62858355d07, Swift 3f8c798cfe25bbb)
Target: x86_64-unknown-freebsd14.3
Build config: +assertions

$ swift build
... Compiling Prometheus NIOLock.swift ...
Build complete! (15.77s)

$ swift test
... 40 tests, with 0 failures (0 unexpected) ...
✔ Test run passed.
```

Without this change `Prometheus` fails to compile on the same
toolchain.

### Checks

- [x] Builds on Linux/Darwin (no change there, all changes guarded
      behind `#if os(FreeBSD) || os(OpenBSD)`).
- [x] Builds + passes existing 40 tests on FreeBSD 15.0 with Swift
      6.3-dev preview toolchain.
- [x] Same pattern as [apple/swift-log#387][log-pr] /
      [apple/swift-http-types#123][sht-pr].
- [x] Commit title follows the project's Conventional Commits
      convention (`feat: ...`).
