### PR TITLE
Add environment variable configuration for default histogram buckets

### DIFF
--- a/Sources/Prometheus/Docs.docc/swift-metrics.md
+++ b/Sources/Prometheus/Docs.docc/swift-metrics.md
@@ -171,4 +171,31 @@ Now a `Timer` with the label "long" will use the buckets
 
 The same functionality is also available for ``ValueHistogram`` and aggregating `Recorder`s.
 
+Buckets from the environment:
+
+The default buckets can also be set with environment variables, allowing operators to tune the
+default histogram buckets without code changes:
+
+```bash
+export SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS=0.05,0.1,0.25,0.5,1,5
+```
+
+Values from `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS` are interpreted as seconds for duration
+histograms and as raw upper bounds for value histograms. Bucket upper bounds must be finite,
+strictly increasing numbers, and duration bucket upper bounds must additionally be zero or greater.
+If the variable is unset or its value is malformed, it is ignored and the built-in default buckets
+are used instead. Buckets that are configured explicitly in code, as shown in the examples above,
+take precedence over the environment.
+
+If duration and value histograms need different default buckets, use the more specific
+environment variables:
+
+```bash
+export SWIFT_PROMETHEUS_DEFAULT_DURATION_HISTOGRAM_BUCKETS=0.05,0.1,0.25,0.5,1,5
+export SWIFT_PROMETHEUS_DEFAULT_VALUE_HISTOGRAM_BUCKETS=5,25,100,500,1000
+```
+
+These specific variables take precedence over `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS`. A variable
+whose value is malformed is ignored, as if it were unset.
+
 [Swift Metrics]: https://github.com/apple/swift-metrics

--- a/Sources/Prometheus/PrometheusMetricsFactory.swift
+++ b/Sources/Prometheus/PrometheusMetricsFactory.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import CoreMetrics
+import Foundation
 
 /// A wrapper around ``PrometheusCollectorRegistry`` to implement the `swift-metrics` `MetricsFactory` protocol
 public struct PrometheusMetricsFactory: Sendable {
@@ -30,6 +31,11 @@ public struct PrometheusMetricsFactory: Sendable {
     /// The default histogram buckets for a ``DurationHistogram``. If there is no explicit overwrite
     /// via ``durationHistogramBuckets``, the buckets provided here will be used for any new
     /// Swift Metrics `Timer` type.
+    ///
+    /// ``init(registry:)`` reads the initial value of this property from the
+    /// `SWIFT_PROMETHEUS_DEFAULT_DURATION_HISTOGRAM_BUCKETS` or
+    /// `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS` environment variable, falling back to the built-in
+    /// default buckets if both variables are unset or their values are malformed.
     public var defaultDurationHistogramBuckets: [Duration]
 
     /// The histogram buckets for a ``DurationHistogram`` per Timer label
@@ -38,6 +44,11 @@ public struct PrometheusMetricsFactory: Sendable {
     /// The default histogram buckets for a ``ValueHistogram``. If there is no explicit overwrite
     /// via ``valueHistogramBuckets``, the buckets provided here will be used for any new
     /// Swift Metrics `Summary` type.
+    ///
+    /// ``init(registry:)`` reads the initial value of this property from the
+    /// `SWIFT_PROMETHEUS_DEFAULT_VALUE_HISTOGRAM_BUCKETS` or
+    /// `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS` environment variable, falling back to the built-in
+    /// default buckets if both variables are unset or their values are malformed.
     public var defaultValueHistogramBuckets: [Double]
 
     /// The histogram buckets for a ``ValueHistogram`` per label
@@ -48,40 +59,139 @@ public struct PrometheusMetricsFactory: Sendable {
     public var nameAndLabelSanitizer:
         @Sendable (_ name: String, _ labels: [(String, String)]) -> (String, [(String, String)])
 
+    /// Creates a new ``PrometheusMetricsFactory``.
+    ///
+    /// The initial values of ``defaultDurationHistogramBuckets`` and
+    /// ``defaultValueHistogramBuckets`` can be configured with environment variables, allowing
+    /// operators to tune the default histogram buckets without code changes:
+    ///
+    /// - `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS` is a comma-separated list of bucket upper bounds
+    ///   used for duration and value histograms, e.g. `0.05,0.1,0.25,0.5,1,5`. Values are
+    ///   interpreted as seconds for duration histograms and as raw values for value histograms.
+    /// - `SWIFT_PROMETHEUS_DEFAULT_DURATION_HISTOGRAM_BUCKETS` is a comma-separated list of bucket
+    ///   upper bounds in seconds, e.g. `0.05,0.1,0.25,0.5,1,5`. If set, it takes precedence over
+    ///   `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS` for duration histograms.
+    /// - `SWIFT_PROMETHEUS_DEFAULT_VALUE_HISTOGRAM_BUCKETS` is a comma-separated list of bucket
+    ///   upper bounds, e.g. `5,25,100,500,1000`. If set, it takes precedence over
+    ///   `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS` for value histograms.
+    ///
+    /// Bucket upper bounds must be finite, strictly increasing numbers. Duration bucket upper
+    /// bounds must additionally be zero or greater. A variable whose value is malformed is
+    /// ignored, as if it were unset. If no applicable variable provides valid buckets, the
+    /// built-in default buckets are used. Buckets that
+    /// are set explicitly in code, by assigning to ``defaultDurationHistogramBuckets``,
+    /// ``defaultValueHistogramBuckets``, ``durationHistogramBuckets`` or
+    /// ``valueHistogramBuckets``, always take precedence over the environment.
+    ///
+    /// - Parameter registry: The ``PrometheusCollectorRegistry`` that is used to generate the
+    ///   swift-metrics handlers
     public init(registry: PrometheusCollectorRegistry = Self.defaultRegistry) {
+        self.init(registry: registry, environment: { ProcessInfo.processInfo.environment[$0] })
+    }
+
+    /// Creates a new ``PrometheusMetricsFactory``, reading the default histogram buckets from
+    /// the provided environment.
+    ///
+    /// - Parameters:
+    ///   - registry: The ``PrometheusCollectorRegistry`` that is used to generate the
+    ///     swift-metrics handlers
+    ///   - environment: Returns the value for the given environment variable name. This is a
+    ///     parameter so that tests can run without modifying the process environment.
+    init(registry: PrometheusCollectorRegistry, environment: (String) -> String?) {
         self.registry = registry
+        let defaultHistogramBuckets = environment(Self.histogramBucketsEnvironmentVariable)
 
         self.durationHistogramBuckets = [:]
-        self.defaultDurationHistogramBuckets = [
-            .milliseconds(5),
-            .milliseconds(10),
-            .milliseconds(25),
-            .milliseconds(50),
-            .milliseconds(100),
-            .milliseconds(250),
-            .milliseconds(500),
-            .seconds(1),
-            .milliseconds(2500),
-            .seconds(5),
-            .seconds(10),
-        ]
+        self.defaultDurationHistogramBuckets = environment(Self.durationHistogramBucketsEnvironmentVariable)
+            .flatMap(Self.parseDurationHistogramBuckets)
+            ?? defaultHistogramBuckets.flatMap(Self.parseDurationHistogramBuckets)
+            ?? Self.builtInDurationHistogramBuckets
 
         self.valueHistogramBuckets = [:]
-        self.defaultValueHistogramBuckets = [
-            5,
-            10,
-            25,
-            50,
-            100,
-            250,
-            500,
-            1000,
-            2500,
-            5000,
-            10000,
-        ]
+        self.defaultValueHistogramBuckets = environment(Self.valueHistogramBucketsEnvironmentVariable)
+            .flatMap(Self.parseValueHistogramBuckets)
+            ?? defaultHistogramBuckets.flatMap(Self.parseValueHistogramBuckets)
+            ?? Self.builtInValueHistogramBuckets
 
         self.nameAndLabelSanitizer = { ($0, $1) }
+    }
+}
+
+extension PrometheusMetricsFactory {
+    static let builtInDurationHistogramBuckets: [Duration] = [
+        .milliseconds(5),
+        .milliseconds(10),
+        .milliseconds(25),
+        .milliseconds(50),
+        .milliseconds(100),
+        .milliseconds(250),
+        .milliseconds(500),
+        .seconds(1),
+        .milliseconds(2500),
+        .seconds(5),
+        .seconds(10),
+    ]
+
+    static let builtInValueHistogramBuckets: [Double] = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]
+
+    /// The name of the environment variable that provides the initial value of all default
+    /// histogram buckets. See ``init(registry:)`` for details.
+    static let histogramBucketsEnvironmentVariable =
+        "SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS"
+
+    /// The name of the environment variable that provides the initial value of
+    /// ``defaultDurationHistogramBuckets``. See ``init(registry:)`` for details.
+    static let durationHistogramBucketsEnvironmentVariable =
+        "SWIFT_PROMETHEUS_DEFAULT_DURATION_HISTOGRAM_BUCKETS"
+
+    /// The name of the environment variable that provides the initial value of
+    /// ``defaultValueHistogramBuckets``. See ``init(registry:)`` for details.
+    static let valueHistogramBucketsEnvironmentVariable =
+        "SWIFT_PROMETHEUS_DEFAULT_VALUE_HISTOGRAM_BUCKETS"
+
+    /// Parses a comma-separated list of histogram bucket upper bounds, e.g. `5,25,100,500`.
+    ///
+    /// Whitespace around values is ignored. Returns `nil` if the list is empty or contains empty
+    /// segments, if a value can not be parsed as a finite `Double`, or if the values are not
+    /// strictly increasing.
+    static func parseValueHistogramBuckets(_ string: String) -> [Double]? {
+        var buckets = [Double]()
+        for var segment in string.split(separator: ",", omittingEmptySubsequences: false) {
+            while segment.first?.isWhitespace == true {
+                segment.removeFirst()
+            }
+            while segment.last?.isWhitespace == true {
+                segment.removeLast()
+            }
+            guard let bucket = Double(segment), bucket.isFinite else {
+                return nil
+            }
+            if let last = buckets.last, bucket <= last {
+                return nil
+            }
+            buckets.append(bucket)
+        }
+        return buckets.isEmpty ? nil : buckets
+    }
+
+    /// Parses a comma-separated list of duration histogram bucket upper bounds in seconds,
+    /// e.g. `0.05,0.1,0.25,0.5,1,5`.
+    ///
+    /// In addition to the rules of ``parseValueHistogramBuckets(_:)``, every value must be zero
+    /// or greater and representable as a `Duration`.
+    static func parseDurationHistogramBuckets(_ string: String) -> [Duration]? {
+        guard let seconds = self.parseValueHistogramBuckets(string) else {
+            return nil
+        }
+        var buckets = [Duration]()
+        for value in seconds {
+            // `Duration` counts attoseconds in an Int128; converting a `Double` beyond its range traps.
+            guard value >= 0, value * 1e18 < 0x1p127 else {
+                return nil
+            }
+            buckets.append(.seconds(value))
+        }
+        return buckets
     }
 }
 

--- a/Tests/PrometheusTests/PrometheusMetricsFactoryEnvironmentTests.swift
+++ b/Tests/PrometheusTests/PrometheusMetricsFactoryEnvironmentTests.swift
@@ -1,0 +1,168 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftPrometheus open source project
+//
+// Copyright (c) 2018-2026 SwiftPrometheus project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftPrometheus project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+@testable import Prometheus
+
+final class PrometheusMetricsFactoryEnvironmentTests: XCTestCase {
+    private static let defaultBucketsVariable = PrometheusMetricsFactory.histogramBucketsEnvironmentVariable
+    private static let durationBucketsVariable = PrometheusMetricsFactory.durationHistogramBucketsEnvironmentVariable
+    private static let valueBucketsVariable = PrometheusMetricsFactory.valueHistogramBucketsEnvironmentVariable
+
+    private func makeFactory(_ environment: [String: String] = [:]) -> PrometheusMetricsFactory {
+        self.makeFactory(environment: { environment[$0] })
+    }
+
+    private func makeFactory(environment: (String) -> String?) -> PrometheusMetricsFactory {
+        PrometheusMetricsFactory(registry: PrometheusCollectorRegistry(), environment: environment)
+    }
+
+    func testParseValueHistogramBuckets() {
+        XCTAssertEqual(
+            PrometheusMetricsFactory.parseValueHistogramBuckets("0.1,0.2,0.5,.75,0.9"),
+            [0.1, 0.2, 0.5, 0.75, 0.9]
+        )
+        XCTAssertEqual(PrometheusMetricsFactory.parseValueHistogramBuckets("1"), [1])
+        XCTAssertEqual(PrometheusMetricsFactory.parseValueHistogramBuckets(" 5,\t10 , 25 "), [5, 10, 25])
+        XCTAssertEqual(PrometheusMetricsFactory.parseValueHistogramBuckets("1e-3,1e3"), [0.001, 1000])
+        XCTAssertEqual(PrometheusMetricsFactory.parseValueHistogramBuckets("-10,-5,0,5"), [-10, -5, 0, 5])
+    }
+
+    func testParseValueHistogramBucketsRejectsMalformedInput() {
+        for input in ["", " ", ",", ",1", "1,", "1,,2", "0.1;0.2", "0.1,foo", "0.1,inf", "0.1,nan"] {
+            XCTAssertNil(PrometheusMetricsFactory.parseValueHistogramBuckets(input))
+        }
+
+        for input in ["1,1", "2,1"] {
+            XCTAssertNil(PrometheusMetricsFactory.parseValueHistogramBuckets(input))
+        }
+    }
+
+    func testParseDurationHistogramBuckets() {
+        XCTAssertEqual(
+            PrometheusMetricsFactory.parseDurationHistogramBuckets("0.1,0.2,0.5,.75,0.9"),
+            [
+                .milliseconds(100),
+                .milliseconds(200),
+                .milliseconds(500),
+                .milliseconds(750),
+                .milliseconds(900),
+            ]
+        )
+        XCTAssertEqual(
+            PrometheusMetricsFactory.parseDurationHistogramBuckets("0,1,60"),
+            [.seconds(0), .seconds(1), .seconds(60)]
+        )
+    }
+
+    func testParseDurationHistogramBucketsRejectsNegativeAndUnrepresentableValues() {
+        XCTAssertNil(PrometheusMetricsFactory.parseDurationHistogramBuckets("-1,1"))
+        // 1e300 seconds is finite but not representable as a `Duration`.
+        XCTAssertNil(PrometheusMetricsFactory.parseDurationHistogramBuckets("1,1e300"))
+        XCTAssertNotNil(PrometheusMetricsFactory.parseValueHistogramBuckets("1,1e300"))
+    }
+
+    func testInitReadsDefaultBucketsFromEnvironment() {
+        let factory = self.makeFactory([Self.defaultBucketsVariable: "0.5,1,5"])
+
+        XCTAssertEqual(factory.defaultDurationHistogramBuckets, [.milliseconds(500), .seconds(1), .seconds(5)])
+        XCTAssertEqual(factory.defaultValueHistogramBuckets, [0.5, 1, 5])
+    }
+
+    func testInitReadsSpecificBucketsFromEnvironment() {
+        let factory = self.makeFactory([
+            Self.durationBucketsVariable: "0.5,1,5",
+            Self.valueBucketsVariable: "10,100,1000",
+        ])
+
+        XCTAssertEqual(factory.defaultDurationHistogramBuckets, [.milliseconds(500), .seconds(1), .seconds(5)])
+        XCTAssertEqual(factory.defaultValueHistogramBuckets, [10, 100, 1000])
+    }
+
+    func testSpecificBucketsTakePrecedenceOverDefaultBucketsEnvironment() {
+        let factory = self.makeFactory([
+            Self.defaultBucketsVariable: "0.5,1,5",
+            Self.durationBucketsVariable: "10,20,30",
+            Self.valueBucketsVariable: "100,200,300",
+        ])
+
+        XCTAssertEqual(factory.defaultDurationHistogramBuckets, [.seconds(10), .seconds(20), .seconds(30)])
+        XCTAssertEqual(factory.defaultValueHistogramBuckets, [100, 200, 300])
+    }
+
+    func testMalformedSpecificBucketsFallBackToDefaultBucketsEnvironment() {
+        let factory = self.makeFactory([
+            Self.defaultBucketsVariable: "0.5,1,5",
+            Self.durationBucketsVariable: "oops",
+        ])
+
+        XCTAssertEqual(factory.defaultDurationHistogramBuckets, [.milliseconds(500), .seconds(1), .seconds(5)])
+        XCTAssertEqual(factory.defaultValueHistogramBuckets, [0.5, 1, 5])
+    }
+
+    func testDefaultBucketsEnvironmentAppliesPerHistogramKind() {
+        // Negative upper bounds are valid for value histograms but not for duration histograms,
+        // so only the value buckets are taken from the shared variable.
+        let factory = self.makeFactory([Self.defaultBucketsVariable: "-5,0,5"])
+
+        XCTAssertEqual(factory.defaultDurationHistogramBuckets, PrometheusMetricsFactory.builtInDurationHistogramBuckets)
+        XCTAssertEqual(factory.defaultValueHistogramBuckets, [-5, 0, 5])
+    }
+
+    func testInitUsesBuiltInBucketsIfEnvironmentIsUnset() {
+        let factory = self.makeFactory()
+
+        XCTAssertEqual(factory.defaultDurationHistogramBuckets, PrometheusMetricsFactory.builtInDurationHistogramBuckets)
+        XCTAssertEqual(factory.defaultValueHistogramBuckets, PrometheusMetricsFactory.builtInValueHistogramBuckets)
+    }
+
+    func testInitUsesBuiltInBucketsIfEnvironmentIsMalformed() {
+        let factory = self.makeFactory(environment: { _ in "0.5,0.1,oops" })
+
+        XCTAssertEqual(factory.defaultDurationHistogramBuckets, PrometheusMetricsFactory.builtInDurationHistogramBuckets)
+        XCTAssertEqual(factory.defaultValueHistogramBuckets, PrometheusMetricsFactory.builtInValueHistogramBuckets)
+    }
+
+    func testTimerUsesDurationBucketsFromEnvironment() {
+        let registry = PrometheusCollectorRegistry()
+        let factory = PrometheusMetricsFactory(
+            registry: registry,
+            environment: { $0 == Self.defaultBucketsVariable ? "0.1,0.2,0.5,.75,0.9" : nil }
+        )
+
+        let timer = factory.makeTimer(label: "request_duration_seconds", dimensions: [])
+        timer.recordNanoseconds(300_000_000)  // 300ms
+
+        let output = registry.emitToString()
+        XCTAssertTrue(output.contains(#"request_duration_seconds_bucket{le="0.5"} 1"#))
+        XCTAssertTrue(output.contains(#"request_duration_seconds_sum 0.3"#))
+    }
+
+    func testExplicitlyConfiguredBucketsTakePrecedenceOverEnvironment() {
+        let registry = PrometheusCollectorRegistry()
+        var factory = PrometheusMetricsFactory(
+            registry: registry,
+            environment: { _ in "1,2,3" }
+        )
+        factory.durationHistogramBuckets["explicitly_configured"] = [.seconds(10)]
+
+        XCTAssertEqual(factory.defaultDurationHistogramBuckets, [.seconds(1), .seconds(2), .seconds(3)])
+
+        let timer = factory.makeTimer(label: "explicitly_configured", dimensions: [])
+        timer.recordNanoseconds(1)
+
+        XCTAssertTrue(registry.emitToString().contains(#"explicitly_configured_bucket{le="10.0"} 1"#))
+    }
+}


### PR DESCRIPTION
Fixes #142.

## Summary

This adds environment-variable configuration for the default histogram buckets used by `PrometheusMetricsFactory`.

The main variable is:

- `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS`

This matches the variable proposed in #142 and applies to both default duration histogram buckets and default value histogram buckets. Values are interpreted as seconds for duration histograms and as raw upper bounds for value histograms.

Because Swift Prometheus exposes separate defaults for duration and value histograms, this PR also adds more specific override variables:

- `SWIFT_PROMETHEUS_DEFAULT_DURATION_HISTOGRAM_BUCKETS`
- `SWIFT_PROMETHEUS_DEFAULT_VALUE_HISTOGRAM_BUCKETS`

Those typed variables take precedence over `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS` when set to valid values.

Explicit configuration in code still takes precedence over environment-derived defaults.

## Validation

Malformed values are ignored as if the variable were unset: a malformed specific variable falls back to `SWIFT_PROMETHEUS_DEFAULT_HISTOGRAMS`, then to the built-in defaults. The parser rejects:

- empty lists
- non-finite values
- non-numeric values
- repeated or decreasing bucket upper bounds
- empty comma-separated elements such as `1,,2`
- negative duration bucket upper bounds
- duration values too large to represent as a `Duration` (converting them would trap, so environment input cannot crash the process)

## Testing

- `swift test`
- `git diff --check origin/main...HEAD`
